### PR TITLE
ci: set least-privilege permissions on build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.txt ./...

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.26.x
+          go-version: "1.25.10"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.26.x
+          go-version: "1.25.10"
 
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.txt ./...

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,9 @@ on:
       - "v*"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary
Two ci/workflow fixes:

1. **Adds top-level `permissions: contents: read`** to `.github/workflows/build.yaml`. Resolves the three open CodeQL `actions/missing-workflow-permissions` alerts:
   - [#1](https://github.com/richie-tt/mariadb-healthcheck/security/code-scanning/1) — `lint` job
   - [#2](https://github.com/richie-tt/mariadb-healthcheck/security/code-scanning/2) — `test` job
   - [#3](https://github.com/richie-tt/mariadb-healthcheck/security/code-scanning/3) — `build` job

2. **Pins Go to `1.25.10`** (from `1.25.x`) to satisfy `govulncheck`. The `actions/go-versions` manifest was resolving `1.25.x` to `1.25.9`, which is flagged for [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971) (`net.Dialer` / `net.Listen` panic on NUL byte). 1.25.10 contains the fix and matches the `go 1.25` line in `go.mod`, keeping `golangci-lint v2.8.0` (built against Go 1.25) compatible.

## Why `contents: read` is sufficient
None of the jobs need `GITHUB_TOKEN` write access:
- `lint`: checkout + golangci-lint + govulncheck (read only)
- `test`: checkout + `go test` + Codecov upload (uses `CODECOV_TOKEN`)
- `build`: checkout + Docker buildx + push to Docker Hub (uses `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`)

## Test plan
- [x] CI run on this PR passes (Lint + Test + CodeQL)
- [x] Build job correctly skipped on PR (only runs on tag push)
- [ ] CodeQL re-scan after merge dismisses alerts #1–#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)